### PR TITLE
Fix VHDX logs renaming

### DIFF
--- a/IRCP-Lab-Multi.ps1
+++ b/IRCP-Lab-Multi.ps1
@@ -344,9 +344,9 @@ foreach ($vhdx in $vhdxImages)
         Write-Host -ForegroundColor Yellow "============ $OSDriveLetter Dismounted"
         Write-Host ""
         Write-Host -ForegroundColor Yellow "============ Kape Complete on $OSDriveLetter Drive for $($vhdx.basename)"
-        Move-Item -Path .\Evidence\$($vmdk.basename)\Modules\Registry\*_BasicSystemInfo_Output.csv .\Evidence\$($vmdk.basename)\TargetSystemInfo.csv
-        Move-Item -Path .\Evidence\$($vmdk.basename)\Modules\*.txt -Destination .\Evidence\$($vmdk.basename)\kapeModules.log
-        Move-Item -Path .\Evidence\$($vmdk.basename)\Targets\*.txt -Destination .\Evidence\$($vmdk.basename)\kapeTargets.log
+        Move-Item -Path .\Evidence\$($vhdx.basename)\Modules\Registry\*_BasicSystemInfo_Output.csv .\Evidence\$($vhdx.basename)\TargetSystemInfo.csv
+        Move-Item -Path .\Evidence\$($vhdx.basename)\Modules\*.txt -Destination .\Evidence\$($vhdx.basename)\kapeModules.log
+        Move-Item -Path .\Evidence\$($vhdx.basename)\Targets\*.txt -Destination .\Evidence\$($vhdx.basename)\kapeTargets.log
         Start-Sleep -Seconds 5
         break
         }             

--- a/IRCP-Lab-Multi.ps1
+++ b/IRCP-Lab-Multi.ps1
@@ -10,7 +10,7 @@
 ####################### Kape Targets & Modules ########################
 
                     $kapeTargets = "!SANS_Triage"
-                    $kapeModules = "!EZParser"
+                    $kapeModules = "!EZParser,Chainsaw"
 
 #######################################################################
 


### PR DESCRIPTION
Fixes issue where renaming of '*_BasicSystemInfo_Output.csv' and kape log files failed for VHDX files as it was looking for a path that did not exist (was looking at the vmdk variable instead of vhdx).